### PR TITLE
fea/runtime_type_checking

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -96,7 +96,7 @@ def demo_custom_writer():
             with self.__lock:
                 print(buffer, file=self.__file)
 
-    tv.config_output(writer=FileSyncWriter(sys.stdout))
+    tv.config(writer=FileSyncWriter(sys.stdout))
 
     def parallel_step(step: tv.TestStep):
         with step.scope():
@@ -122,7 +122,7 @@ def demo_custom_writer():
                 t.join()
     finally:
         # return to default, useful for rest of demos
-        tv.config_output(StdoutWriter())
+        tv.config(writer=StdoutWriter())
 
 
 @banner
@@ -158,7 +158,7 @@ def demo_python_logging_io():
         def write(self, buffer: str):
             logging.info(buffer)
 
-    tv.config_output(writer=LoggingWriter())
+    tv.config(writer=LoggingWriter())
 
     class Handler(logging.StreamHandler):
         def __init__(self, run: tv.TestRun):
@@ -193,7 +193,7 @@ def demo_python_logging_io():
             log.debug("debug log sample")
             log.warning("warn level here")
     finally:
-        tv.config_output(StdoutWriter())
+        tv.config(writer=StdoutWriter())
         log.removeHandler(log.handlers[-1])
 
 

--- a/ocptv/output/__init__.py
+++ b/ocptv/output/__init__.py
@@ -1,7 +1,6 @@
 # following are the only public api exports
-from .config import config_output
+from .config import StdoutWriter, Writer, config
 from .dut import Dut, Subcomponent
-from .emit import StdoutWriter, Writer
 from .measurement import Validator
 from .objects import (
     DiagnosisType,

--- a/ocptv/output/emit.py
+++ b/ocptv/output/emit.py
@@ -6,39 +6,10 @@ import json
 import threading
 import time
 import typing as ty
-from abc import ABC, abstractmethod
 from enum import Enum
 
-from ocptv.api import export_api
-
+from .config import Writer
 from .objects import ArtifactType, Root, RootArtifactType, SchemaVersion
-
-
-class Writer(ABC):  # pragma: no cover
-    """
-    Abstract writer interface for the lib. Should be used as a base for
-    any output writer implementation (for typing purposes).
-    NOTE: Writer impls must ensure thread safety.
-    """
-
-    @abstractmethod
-    def write(self, buffer: str):
-        pass
-
-
-@export_api
-class StdoutWriter(Writer):
-    """
-    A simple writer that prints the json to stdout.
-    """
-
-    def __init__(self):
-        self._lock = threading.Lock()
-
-    def write(self, buffer: str):
-        with self._lock:
-            print(buffer)
-
 
 Primitive = ty.Union[float, int, bool, str, None]
 JSON = ty.Union[ty.Dict[str, "JSON"], ty.List["JSON"], Primitive]

--- a/ocptv/output/objects.py
+++ b/ocptv/output/objects.py
@@ -23,6 +23,8 @@ if ty.TYPE_CHECKING:  # pragma: no cover
 else:
     Protocol = object
 
+from .runtime_checks import check_field_types
+
 
 class ArtifactType(Protocol):
     """
@@ -65,6 +67,9 @@ class SchemaVersion:
         default=OCPVersion.VERSION_2_0.value[1],
         metadata={"spec_field": "minor"},
     )
+
+    def __post_init__(self):
+        check_field_types(self)
 
 
 # NOTE: This is intentionally not a dataclass. It is exported as public api
@@ -149,6 +154,9 @@ class Log:
         metadata={"spec_field": "sourceLocation"},
     )
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 @dc.dataclass
 class File:
@@ -184,6 +192,9 @@ class File:
     )
 
     metadata: ty.Optional[Metadata]
+
+    def __post_init__(self):
+        check_field_types(self)
 
 
 class SubcomponentType(Enum):
@@ -239,6 +250,9 @@ class Subcomponent:
         metadata={"spec_field": "revision"},
     )
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 class DiagnosisType(Enum):
     """
@@ -270,6 +284,9 @@ class PlatformInfo:
     info: str = dc.field(
         metadata={"spec_field": "info"},
     )
+
+    def __post_init__(self):
+        check_field_types(self)
 
 
 class SoftwareType(Enum):
@@ -326,6 +343,9 @@ class SoftwareInfo:
     computer_system: ty.Optional[str] = dc.field(
         metadata={"spec_field": "computerSystem"},
     )
+
+    def __post_init__(self):
+        check_field_types(self)
 
 
 @dc.dataclass
@@ -389,6 +409,9 @@ class HardwareInfo:
         metadata={"spec_field": "manager"},
     )
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 def format_hardware_info(obj: HardwareInfo) -> str:
     return obj.id
@@ -428,6 +451,9 @@ class DutInfo:
     )
 
     metadata: ty.Optional[Metadata]
+
+    def __post_init__(self):
+        check_field_types(self)
 
 
 @dc.dataclass
@@ -471,6 +497,9 @@ class Diagnosis:
         metadata={"spec_field": "sourceLocation"},
     )
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 @dc.dataclass
 class Error:
@@ -505,10 +534,19 @@ class Error:
         metadata={"spec_field": "sourceLocation"},
     )
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 MeasurementValueType = ty.Union[float, int, bool, str]
 
-ValidatorValueType = ty.Union[ty.List["ValidatorValueType"], MeasurementValueType]
+ValidatorValueType = ty.Union[
+    ty.List[float],
+    ty.List[int],
+    ty.List[bool],
+    ty.List[str],
+    MeasurementValueType,
+]
 
 
 class ValidatorType(Enum):
@@ -562,6 +600,9 @@ class Validator:
 
     metadata: ty.Optional[Metadata]
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 @dc.dataclass
 class Measurement:
@@ -601,6 +642,9 @@ class Measurement:
 
     subcomponent: ty.Optional[Subcomponent]
     metadata: ty.Optional[Metadata]
+
+    def __post_init__(self):
+        check_field_types(self)
 
 
 @dc.dataclass
@@ -642,6 +686,9 @@ class MeasurementSeriesStart:
     subcomponent: ty.Optional[Subcomponent]
     metadata: ty.Optional[Metadata]
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 @dc.dataclass
 class MeasurementSeriesEnd:
@@ -663,6 +710,9 @@ class MeasurementSeriesEnd:
     total_count: int = dc.field(
         metadata={"spec_field": "totalCount"},
     )
+
+    def __post_init__(self):
+        check_field_types(self)
 
 
 @dc.dataclass
@@ -699,17 +749,24 @@ class MeasurementSeriesElement:
 
     metadata: ty.Optional[Metadata]
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 MeasurementSeriesType = ty.Union[MeasurementSeriesStart, MeasurementSeriesEnd, MeasurementSeriesElement]
 
-# note: these must specify some bounds for the extension content in python, despite
-# the spec saying that it can be anything. This is necessary for the json serializer
-# to actually know how to output the data.
-ExtensionContentType = ty.Union[
-    ty.Dict[str, "ExtensionContentType"],
-    ty.List["ExtensionContentType"],
-    ty.Union[float, int, bool, str, None],
-]
+if ty.TYPE_CHECKING:
+    # note: these must specify some bounds for the extension content in python, despite
+    # the spec saying that it can be anything. This is necessary for the json serializer
+    # to actually know how to output the data.
+    ExtensionContentType = ty.Union[  # pragma: no cover
+        ty.Dict[str, "ExtensionContentType"],
+        ty.List["ExtensionContentType"],
+        ty.Union[float, int, bool, str, None],
+    ]
+else:
+    # the runtime checker cannot deal with recursive types, and this is meant to be any
+    ExtensionContentType = ty.Any
 
 
 @dc.dataclass
@@ -732,6 +789,9 @@ class Extension:
     content: ExtensionContentType = dc.field(
         metadata={"spec_field": "content"},
     )
+
+    def __post_init__(self):
+        check_field_types(self)
 
 
 @dc.dataclass
@@ -764,6 +824,9 @@ class RunStart:
     )
 
     dut_info: DutInfo
+
+    def __post_init__(self):
+        check_field_types(self)
 
 
 class TestStatus(Enum):
@@ -827,6 +890,9 @@ class RunEnd:
         },
     )
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 @dc.dataclass
 class RunArtifact:
@@ -861,6 +927,9 @@ class StepStart:
         metadata={"spec_field": "name"},
     )
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 @dc.dataclass
 class StepEnd:
@@ -881,6 +950,9 @@ class StepEnd:
             "formatter": format_enum,
         },
     )
+
+    def __post_init__(self):
+        check_field_types(self)
 
 
 @dc.dataclass
@@ -912,6 +984,9 @@ class StepArtifact:
         Extension,
     ]
 
+    def __post_init__(self):
+        check_field_types(self)
+
 
 RootArtifactType = ty.Union[SchemaVersion, RunArtifact, StepArtifact]
 
@@ -939,3 +1014,6 @@ class Root:
             "formatter": format_timestamp,
         },
     )
+
+    # def __post_init__(self):
+    #     check_field_types(self)

--- a/ocptv/output/objects.py
+++ b/ocptv/output/objects.py
@@ -1015,5 +1015,5 @@ class Root:
         },
     )
 
-    # def __post_init__(self):
-    #     check_field_types(self)
+    def __post_init__(self):
+        check_field_types(self)

--- a/ocptv/output/runtime_checks.py
+++ b/ocptv/output/runtime_checks.py
@@ -1,0 +1,197 @@
+import dataclasses as dc
+import sys
+import typing as ty
+
+if ty.TYPE_CHECKING:  # pragma: no cover
+    # mypy extension for py37
+    from typing_extensions import Protocol
+else:
+    Protocol = object
+
+if sys.version_info >= (3, 8):  # pragma: no cover
+    from typing import get_args, get_origin
+else:  # pragma: no cover
+    # following are very simple substitutes for their py3.8+ equivalents, but
+    # they are sufficient for the usage here in `check_field_types`
+    def get_origin(typ: ty.Type):
+        if not hasattr(typ, "__origin__"):
+            return None
+        return typ.__origin__
+
+    def get_args(typ: ty.Type):
+        if not hasattr(typ, "__args__"):
+            return None
+        # note: in py37, the __args__ will contain typevar instances if the generic
+        # type was not parametrized in the first place. Remove them because they
+        # serve no purpose in the type checking here.
+        return tuple(x for x in typ.__args__ if not isinstance(x, ty.TypeVar))
+
+
+class Dataclass(Protocol):
+    """
+    Protocol type to describe all low level serializable objects in this file.
+    """
+
+    __dataclass_fields__: ty.ClassVar[dict]
+
+
+Primitive = ty.Union[float, int, bool, str, None]
+CheckedValue = ty.Union[ty.Dict[str, "CheckedValue"], ty.List["CheckedValue"], Dataclass, Primitive]
+
+
+def ellipsis(value: ty.Any, max_length: int = 64) -> str:
+    s = str(value)
+    if len(s) > max_length:
+        return s[:max_length] + "..."
+    return s
+
+
+class TypeCheckError(TypeError):
+    def __init__(
+        self,
+        value: CheckedValue,
+        expected: str,
+        *,
+        trace: ty.List[str],
+    ):
+        self._value = value
+        self._expected = expected
+        self._trace = trace
+
+        parts = [
+            "Cannot use type '{}'".format(type(value).__name__),
+            "  Expected type '{}'".format(expected),
+            "  Path to offending field is '{}'".format(" -> ".join(trace)),
+        ]
+        self._msg = "\n".join(parts)
+
+    def __str__(self):
+        return self._msg
+
+    @property
+    def value(self):
+        return self._value
+
+    @property
+    def expected(self):
+        return self._expected
+
+    @property
+    def trace(self):
+        return self._trace
+
+
+class UnionCheckError(TypeCheckError):
+    def __init__(
+        self,
+        value: CheckedValue,
+        expected: str,
+        *,
+        trace: ty.List[str],
+        tries: ty.List[ty.Union[TypeCheckError, "UnionCheckError"]],
+    ):
+        super().__init__(value, expected, trace=trace)
+        self._tries = tries
+
+        parts = [
+            "Cannot use type '{}' for field value".format(type(value).__name__),
+            "  Expected type '{}'".format(expected),
+            "  Path to offending field is '{}'".format(" -> ".join(trace)),
+        ]
+        parts.append("  Tried checks:")
+
+        def format_tries(tries, indent=1):
+            for t in tries:
+                pre = "  " * indent
+                parts.append("{}Value '{}' did not match expected type '{}'".format(pre, ellipsis(t.value), t.expected))
+                parts.append("{}Path to field is '{}'".format(pre, " -> ".join(t.trace)))
+                if type(t) is UnionCheckError:
+                    format_tries(t._tries, indent + 1)
+
+        format_tries(tries)
+        self._msg = "\n".join(parts)
+
+    def __str__(self):
+        return self._msg
+
+
+def _check_type_any(obj: CheckedValue, hint: ty.Type, trace: ty.List[str]):
+    type_origin = get_origin(hint)
+    type_args = get_args(hint)
+
+    if type_origin is list:
+        # generic type: typ == ty.List[...]
+        if len(type_args) != 1:
+            # for non-parametric generics, args is () so we can't actually
+            # check for the list item types; short return
+            return
+
+        # for list, alias nparams=1
+        item_type = type_args[0]
+
+        if not isinstance(obj, list):
+            raise TypeCheckError(obj, expected=f"List [{item_type}]", trace=trace)
+
+        # unpack generic type to list item
+        for i, v in enumerate(obj):
+            subtrace = trace + [f"List[{i}]"]
+            _check_type_any(v, item_type, subtrace)
+
+    elif type_origin is dict:
+        # generic type: typ == ty.Dict[...]
+        if len(type_args) != 2:
+            # for non-parametric generics, args is () so we can't actually
+            # check for the dict keys or values types; short return
+            return
+
+        # for dict, alias nparams=2
+        key_type, value_type = type_args
+
+        if not isinstance(obj, dict):
+            raise TypeCheckError(obj, expected=f"Dict [{key_type}, {value_type}]", trace=trace)
+
+        # unpack generic type to kv tuple
+        for k, v in obj.items():
+            subtrace = trace + [f"Dict[{k}]"]
+            _check_type_any(k, key_type, subtrace)
+            _check_type_any(v, value_type, subtrace)
+
+    elif type_origin is ty.Union:
+        # for other generic types, get the covered types
+        # note: ty.Optional is ty.Union[x, type(None)] so it still fits here
+
+        any_passed = False
+        errors = []
+        for hint_item in type_args:
+            try:
+                _check_type_any(obj, hint_item, trace)
+                any_passed = True
+                break
+            except TypeCheckError as e:
+                errors.append(e)
+
+        if not any_passed:
+            raise UnionCheckError(obj, expected=f"Union[{type_args}]", trace=trace, tries=errors)
+
+    elif type_origin is not None:
+        raise ValueError(f"unsupported type origin value '{type_origin}'")
+
+    elif hint is ty.Any:
+        # we can't check anything if type is any, so just return
+        return
+
+    elif dc.is_dataclass(obj):
+        for field in dc.fields(obj):
+            subtrace = trace + [f"{obj.__class__.__name__}.{field.name}"]
+            _check_type_any(getattr(obj, field.name), field.type, subtrace)
+
+    elif not isinstance(obj, hint):
+        raise TypeCheckError(obj, expected=hint.__name__, trace=trace)
+
+
+def check_field_types(obj: Dataclass):
+    """
+    Check that the values inside the given dataclass' fields are of the correct
+    type at runtime. Throws TypeError on failures.
+    """
+    _check_type_any(obj, type(obj), trace=[])

--- a/ocptv/output/runtime_checks.py
+++ b/ocptv/output/runtime_checks.py
@@ -27,6 +27,9 @@ else:  # pragma: no cover
         return tuple(x for x in typ.__args__ if not isinstance(x, ty.TypeVar))
 
 
+from .config import get_config
+
+
 class Dataclass(Protocol):
     """
     Protocol type to describe all low level serializable objects in this file.
@@ -192,6 +195,15 @@ def _check_type_any(obj: CheckedValue, hint: ty.Type, trace: ty.List[str]):
 def check_field_types(obj: Dataclass):
     """
     Check that the values inside the given dataclass' fields are of the correct
-    type at runtime. Throws TypeError on failures.
+    type at runtime.
+    This currently covers needed field types used in this lib, but is not generic
+    enough to cover all typing configurations. See tests for more details.
+
+    Can be disabled in lib config. See `ocptv.output.config()`.
+
+    :throws TypeError on failures.
     """
+    if not get_config().enable_runtime_checks:
+        return
+
     _check_type_any(obj, type(obj), trace=[])

--- a/tests/output/conftest.py
+++ b/tests/output/conftest.py
@@ -1,5 +1,6 @@
 import json
 import typing as ty
+from contextlib import contextmanager
 
 import pytest
 
@@ -23,5 +24,18 @@ class MockWriter(Writer):
 @pytest.fixture
 def writer() -> MockWriter:
     w = MockWriter()
-    tv.config_output(w)
+    tv.config(writer=w)
     return w
+
+
+@contextmanager
+def disable_runtime_checks():
+    from ocptv.output.config import get_config
+
+    try:
+        prev = get_config().enable_runtime_checks
+        tv.config(enable_runtime_checks=False)
+
+        yield
+    finally:
+        tv.config(enable_runtime_checks=prev)

--- a/tests/output/test_emit.py
+++ b/tests/output/test_emit.py
@@ -3,9 +3,10 @@ import typing as ty
 
 import pytest
 
-from ocptv.output.emit import ArtifactEmitter, StdoutWriter
+from ocptv.output import StdoutWriter
+from ocptv.output.emit import ArtifactEmitter
 
-from .conftest import MockWriter
+from .conftest import MockWriter, disable_runtime_checks
 
 
 def test_stdout_writer(capsys: pytest.CaptureFixture):
@@ -40,9 +41,10 @@ def test_emit_fails_none_in_nonoptional(writer: MockWriter):
         SPEC_OBJECT: ty.ClassVar[str] = "test"
         nonoptional: str
 
-    e = ArtifactEmitter(writer)
-    with pytest.raises(RuntimeError):
-        e.emit(TestObject(nonoptional=None))  # type: ignore[arg-type]
+    with disable_runtime_checks():
+        e = ArtifactEmitter(writer)
+        with pytest.raises(RuntimeError):
+            e.emit(TestObject(nonoptional=None))  # type: ignore[arg-type]
 
 
 def test_emit_fails_missing_spec_object(writer: MockWriter):
@@ -71,6 +73,7 @@ def test_emil_fails_unserializable_type(writer: MockWriter):
     class Unserializable:
         SPEC_OBJECT: ty.ClassVar[str] = "test"
 
-    e = ArtifactEmitter(writer)
-    with pytest.raises(RuntimeError):
-        e.emit(Unserializable())  # type: ignore[arg-type]
+    with disable_runtime_checks():
+        e = ArtifactEmitter(writer)
+        with pytest.raises(RuntimeError):
+            e.emit(Unserializable())  # type: ignore[arg-type]

--- a/tests/output/test_runtime_checks.py
+++ b/tests/output/test_runtime_checks.py
@@ -1,0 +1,193 @@
+import dataclasses as dc
+import re
+import typing as ty
+
+import pytest
+
+from ocptv.output.runtime_checks import TypeCheckError, check_field_types
+
+
+def test_primitive():
+    @dc.dataclass
+    class A:
+        f1: int
+        f2: str
+
+    try:
+        a = A(f1=1, f2="2")
+        check_field_types(a)
+    except TypeCheckError:
+        pytest.fail("unexpected failed type check")
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f1")):
+        a = A(f1="1", f2="2")  # type: ignore
+        check_field_types(a)
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f2")):
+        a = A(f1=1, f2=2)  # type: ignore
+        check_field_types(a)
+
+
+def test_generic_collection():
+    @dc.dataclass
+    class A:
+        f1: ty.List[int]
+        f2: ty.Dict[str, str]
+
+    try:
+        a = A(f1=[1], f2={"2": "2"})
+        check_field_types(a)
+    except TypeCheckError:
+        pytest.fail("unexpected failed type check")
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f1")):
+        a = A(f1=["1"], f2={"2": "2"})  # type: ignore
+        check_field_types(a)
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f2")):
+        a = A(f1=[1], f2={2: 2})  # type: ignore
+        check_field_types(a)
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f1")):
+        a = A(f1=1, f2={"2": "2"})  # type: ignore
+        check_field_types(a)
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f2")):
+        a = A(f1=[1], f2=2)  # type: ignore
+        check_field_types(a)
+
+
+def test_non_parametric_collections():
+    @dc.dataclass
+    class A:
+        f1: ty.List
+        f2: ty.Dict
+
+    try:
+        a = A(f1=[1], f2={"2": "2"})
+        check_field_types(a)
+    except TypeCheckError:
+        pytest.fail("unexpected failed type check")
+
+
+def test_generic_union():
+    @dc.dataclass
+    class A:
+        f1: ty.Union[int, str, float]
+        f2: ty.Optional[int]
+
+    try:
+        a1 = A(f1=1, f2=2)
+        check_field_types(a1)
+
+        a2 = A(f1="1", f2=None)
+        check_field_types(a2)
+    except TypeCheckError:
+        pytest.fail("unexpected failed type check")
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f1")):
+        a = A(f1=None, f2=None)  # type: ignore
+        check_field_types(a)
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f2")):
+        a = A(f1=1, f2="2")  # type: ignore
+        check_field_types(a)
+
+
+def test_generic_nested_generic():
+    @dc.dataclass
+    class A:
+        f1: ty.Optional[ty.List[int]]
+        f2: ty.Union[ty.List[int], ty.Dict[int, int]]
+
+    try:
+        a1 = A(f1=[1], f2=[2])
+        check_field_types(a1)
+
+        a2 = A(f1=None, f2={2: 2})
+        check_field_types(a2)
+    except TypeCheckError:
+        pytest.fail("unexpected failed type check")
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f1")):
+        a = A(f1=1, f2=[1])  # type: ignore
+        check_field_types(a)
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f1")):
+        a = A(f1=["1"], f2=[1])  # type: ignore
+        check_field_types(a)
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f2")):
+        a = A(f1=None, f2={"2": 2})  # type: ignore
+        check_field_types(a)
+
+
+def test_generic_nested_object():
+    @dc.dataclass
+    class B:
+        f1: int
+        f2: ty.Optional[str] = None
+
+    @dc.dataclass
+    class A:
+        f1: ty.Optional[B]
+        f2: ty.List[ty.Optional[B]]
+
+    try:
+        a1 = A(f1=B(f1=1), f2=[B(f1=1)])
+        check_field_types(a1)
+
+        a2 = A(f1=None, f2=[None])
+        check_field_types(a2)
+
+        a3 = A(f1=B(f1=1, f2=None), f2=[B(f1=1, f2="2")])
+        check_field_types(a3)
+    except TypeCheckError:
+        pytest.fail("unexpected failed type check")
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f1")):
+        a = A(f1=[B(f1=1)], f2=[None])  # type: ignore
+        check_field_types(a)
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f2")):
+        a = A(f1=None, f2=None)  # type: ignore
+        check_field_types(a)
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f1 -> B.f1")):
+        a = A(f1=B(f1="1"), f2=[None])  # type: ignore
+        check_field_types(a)
+
+
+def test_complex():
+    @dc.dataclass
+    class B:
+        f1: int
+        f2: ty.Optional[str] = None
+
+    class C(dict):
+        pass
+
+    @dc.dataclass
+    class A:
+        f1: ty.Union[ty.Optional[B], ty.List[C], ty.Dict[int, ty.Optional[ty.List[ty.Optional[B]]]]]
+
+    with pytest.raises(TypeCheckError, match=re.escape("A.f1 -> Dict[4] -> List[1] -> B.f2")):
+        a = A(
+            f1={
+                1: None,
+                2: [None],
+                3: [B(f1=1)],
+                4: [B(f1=1, f2="2"), B(f1=1, f2=2)],  # type: ignore
+            }
+        )
+        check_field_types(a)
+
+
+def test_unknown_generic_alias():
+    @dc.dataclass
+    class A:
+        f1: ty.Callable
+
+    with pytest.raises(ValueError, match=re.escape("unsupported")):
+        a = A(f1="f1")  # type: ignore
+        check_field_types(a)


### PR DESCRIPTION
- add option to enable runtime type checking for all values being used in lib api
- refactor the config block to take new aspect

other options tried: typeguard, beartype (which is quite nice), but neither of them can produce a path to the field that has the invalid data. Neither do they work with recursive typings (like JSON with forward refs)